### PR TITLE
Resize quality

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ image_storage:
         ALLOWED_PIXEL_DENSITY: [ 1, 2, 3 ]
         ALLOWED_RESOLUTIONS: [ 50x50, 200x200, 300x300, 200x, x200 ]
         ALLOWED_QUALITIES: [ 50, 80, 100 ]
-        RESIZE_QUALITY: 100
+        ENCODE_QUALITY: 90
         MODIFIER_SEPARATOR: ','
         MODIFIER_ASSIGNER: ':'
 

--- a/src/Config/Env.php
+++ b/src/Config/Env.php
@@ -20,7 +20,7 @@ final class Env implements \ArrayAccess, \JsonSerializable
 					ALLOWED_PIXEL_DENSITY = 'ALLOWED_PIXEL_DENSITY',
 					ALLOWED_RESOLUTIONS = 'ALLOWED_RESOLUTIONS',
 					ALLOWED_QUALITIES = 'ALLOWED_QUALITIES',
-					RESIZE_QUALITY = 'RESIZE_QUALITY';
+					ENCODE_QUALITY = 'ENCODE_QUALITY';
 
 	/** @var array  */
 	private $env = [
@@ -33,7 +33,7 @@ final class Env implements \ArrayAccess, \JsonSerializable
 		self::ALLOWED_PIXEL_DENSITY => [],
 		self::ALLOWED_RESOLUTIONS => [],
 		self::ALLOWED_QUALITIES => [],
-		self::RESIZE_QUALITY => 100,
+		self::ENCODE_QUALITY => 90,
 	];
 
 	/**

--- a/src/ImagePersister/DefaultImagePersister.php
+++ b/src/ImagePersister/DefaultImagePersister.php
@@ -84,7 +84,7 @@ class DefaultImagePersister implements IImagePersister
 	 */
 	protected function encodeImage(Intervention\Image\Image $image): string
 	{
-		$image = $image->isEncoded() ? $image : $image->encode(NULL, 100);
+		$image = $image->isEncoded() ? $image : $image->encode(NULL, $this->env[SixtyEightPublishers\ImageStorage\Config\Env::ENCODE_QUALITY]);
 
 		return $image->getEncoded();
 	}

--- a/src/Modifier/Applicator/Format.php
+++ b/src/Modifier/Applicator/Format.php
@@ -40,19 +40,14 @@ final class Format implements IModifierApplicator
 	public function apply(Intervention\Image\Image $image, SixtyEightPublishers\ImageStorage\ImageInfo $info, SixtyEightPublishers\ImageStorage\Modifier\Collection\ModifierValues $values): Intervention\Image\Image
 	{
 		$preserveFormat = TRUE === $info->isNoImage() ?: $values->getOptional(SixtyEightPublishers\ImageStorage\Modifier\PreserveFormat::class, FALSE);
-		$quality = $values->getOptional(SixtyEightPublishers\ImageStorage\Modifier\Quality::class, $this->env[SixtyEightPublishers\ImageStorage\Config\Env::RESIZE_QUALITY]);
-
-		# nothing
-		if (TRUE === $preserveFormat && 100 === $quality) {
-			return $image;
-		}
+		$quality = $values->getOptional(SixtyEightPublishers\ImageStorage\Modifier\Quality::class, $this->env[SixtyEightPublishers\ImageStorage\Config\Env::ENCODE_QUALITY]);
 
 		$imageFormat = array_search($image->mime(), self::SUPPORTED_FORMATS, TRUE);
 		$newFormat = (TRUE === $preserveFormat && $imageFormat) ? $imageFormat : self::DEFAULT_FORMAT;
 
 		# same format
 		if ($imageFormat === $newFormat) {
-			return $image->encode($newFormat, $quality);
+			return $image->encode(NULL, $quality);
 		}
 
 		# change format to jpg


### PR DESCRIPTION
- removed env option `RESIZE_QUALITY`
- added env option `ENCODE_QUALITY` with the default value 90. The option is used for image encoding in classes `DefaultImagePersister` and `Format`
- removed unnecessary condition in an applicator `Format` - an image must be always encoded and image's format must be checked
- modified README.md