### PR TITLE
Configurable cache control headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ image_storage:
         allowed_resolutions: [ 50x50, 200x200, 300x300, 200x, x200 ]
         allowed_qualities: [ 50, 80, 100 ]
         encode_quality: 90
+        cache_max_age: 31536000
         modifier_separator: ','
         modifier_assigner: ':'
 

--- a/src/Config/Config.php
+++ b/src/Config/Config.php
@@ -22,7 +22,8 @@ final class Config implements \ArrayAccess, \JsonSerializable
 					ALLOWED_PIXEL_DENSITY = 'allowed_pixel_density',
 					ALLOWED_RESOLUTIONS = 'allowed_resolutions',
 					ALLOWED_QUALITIES = 'allowed_qualities',
-					ENCODE_QUALITY = 'encode_quality';
+					ENCODE_QUALITY = 'encode_quality',
+					CACHE_MAX_AGE = 'cache_max_age';
 
 	/** @var array  */
 	private $config = [
@@ -38,6 +39,7 @@ final class Config implements \ArrayAccess, \JsonSerializable
 		self::ALLOWED_RESOLUTIONS => [],
 		self::ALLOWED_QUALITIES => [],
 		self::ENCODE_QUALITY => 90,
+		self::CACHE_MAX_AGE => 31536000,
 	];
 
 	/**

--- a/src/ImageServer/LocalImageServer.php
+++ b/src/ImageServer/LocalImageServer.php
@@ -162,6 +162,6 @@ final class LocalImageServer implements IImageServer
 			$path = $this->getFilePath($noImageInfo, $modifiers);
 		}
 
-		return new Response\ImageResponse($this->imagePersister->getFilesystem()->getCache(), $path);
+		return new Response\ImageResponse($this->imagePersister->getFilesystem()->getCache(), $path, (int) $this->config[SixtyEightPublishers\ImageStorage\Config\Config::CACHE_MAX_AGE]);
 	}
 }

--- a/src/SamConfig/ImageStorageConfigGenerator.php
+++ b/src/SamConfig/ImageStorageConfigGenerator.php
@@ -76,6 +76,7 @@ final class ImageStorageConfigGenerator implements IImageStorageConfigGenerator
 		$parameterOverrides['BasePath'] = $config[SixtyEightPublishers\ImageStorage\Config\Config::BASE_PATH];
 		$parameterOverrides['ModifierSeparator'] = $config[SixtyEightPublishers\ImageStorage\Config\Config::MODIFIER_SEPARATOR];
 		$parameterOverrides['ModifierAssigner'] = $config[SixtyEightPublishers\ImageStorage\Config\Config::MODIFIER_ASSIGNER];
+		$parameterOverrides['VersionParameterName'] = $config[SixtyEightPublishers\ImageStorage\Config\Config::VERSION_PARAMETER_NAME];
 		$parameterOverrides['SignatureParameterName'] = $config[SixtyEightPublishers\ImageStorage\Config\Config::SIGNATURE_PARAMETER_NAME];
 		$parameterOverrides['SignatureKey'] = $config[SixtyEightPublishers\ImageStorage\Config\Config::SIGNATURE_KEY];
 		$parameterOverrides['SignatureAlgorithm'] = $config[SixtyEightPublishers\ImageStorage\Config\Config::SIGNATURE_ALGORITHM];
@@ -85,6 +86,7 @@ final class ImageStorageConfigGenerator implements IImageStorageConfigGenerator
 		$parameterOverrides['EncodeQuality'] = $config[SixtyEightPublishers\ImageStorage\Config\Config::ENCODE_QUALITY];
 		$parameterOverrides['SourceBucketName'] = $sourceAdapter->getBucket();
 		$parameterOverrides['CacheBucketName'] = $cacheAdapter->getBucket();
+		$parameterOverrides['CacheMaxAge'] = $config[SixtyEightPublishers\ImageStorage\Config\Config::CACHE_MAX_AGE];
 		$parameterOverrides['NoImages'] = $noImages;
 		$parameterOverrides['NoImagePatterns'] = $noImagePatterns;
 


### PR DESCRIPTION
- added config option `cache_max_age`
- headers `Cache-Control` and `Expires` are defined by the config option
- options `VersionParameterName` and `CacheMaxAge` are exported to the AWS config