### PR TITLE
Fixed presets usage

### DIFF
--- a/src/Bridge/Nette/DI/ImageStorageExtension.php
+++ b/src/Bridge/Nette/DI/ImageStorageExtension.php
@@ -301,6 +301,7 @@ final class ImageStorageExtension extends CompilerExtension implements FileStora
 				$this->prefix('@config.' . $name),
 			]))
 			->addSetup('setModifiers', [$imageStorageConfig->modifiers])
+			->addSetup('setPresets', [$imageStorageConfig->presets])
 			->addSetup('setApplicators', [$imageStorageConfig->applicators])
 			->addSetup('setValidators', [$imageStorageConfig->validators])
 			->setAutowired(FALSE);

--- a/src/FileInfo.php
+++ b/src/FileInfo.php
@@ -33,7 +33,7 @@ final class FileInfo extends BaseFileInfo implements FileInfoInterface
 	/**
 	 * {@inheritDoc}
 	 */
-	public function getModifiers(): ?array
+	public function getModifiers()
 	{
 		return $this->pathInfo instanceof PathInfoInterface ? $this->pathInfo->getModifiers() : NULL;
 	}

--- a/src/PathInfo.php
+++ b/src/PathInfo.php
@@ -65,7 +65,7 @@ final class PathInfo extends BasePathInfo implements PathInfoInterface
 	/**
 	 * {@inheritDoc}
 	 */
-	public function getModifiers(): ?array
+	public function getModifiers()
 	{
 		return $this->modifiers;
 	}

--- a/src/PathInfoInterface.php
+++ b/src/PathInfoInterface.php
@@ -11,7 +11,7 @@ interface PathInfoInterface extends BasePathInfoInterface
 	/**
 	 * @return NULL|string|array
 	 */
-	public function getModifiers(): ?array;
+	public function getModifiers();
 
 	/**
 	 * @param NULL|string|array $modifiers


### PR DESCRIPTION
- removed strict return type from a method `PathInfoInterface::getModifiers()` (the method can returns null, an array or a string)
- added missing calling of a method `ModifierFacadeInterface::setPresets()` in a compiler extension `ImageStorageExtension`