### PR TITLE
Persistence improvements

### DIFF
--- a/.github/workflows/coding-style.yml
+++ b/.github/workflows/coding-style.yml
@@ -23,6 +23,7 @@ jobs:
         with:
           php-version: 8.1
           tools: composer:v2
+          extensions: imagick
 
       - name: Install dependencies
         run: composer update --no-progress --prefer-dist --prefer-stable --optimize-autoloader --quiet
@@ -42,6 +43,7 @@ jobs:
         with:
           php-version: 8.1
           tools: composer:v2
+          extensions: imagick
 
       - name: Install dependencies
         run: composer update --no-progress --prefer-dist --prefer-stable --optimize-autoloader --quiet

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           php-version: 8.1
           coverage: none
-          extensions: tokenizer
+          extensions: imagick, tokenizer
           tools: composer:v2
 
       - name: Install dependencies

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-versions: ['8.1', '8.2']
+        php-versions: ['8.1', '8.2', '8.3']
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -26,6 +26,7 @@ jobs:
         with:
           php-version: ${{ matrix.php-versions }}
           tools: composer:v2
+          extensions: imagick
 
       - name: Install dependencies
         run: composer update --no-progress --prefer-dist --prefer-stable --optimize-autoloader --quiet

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,14 +6,27 @@ WORKDIR /var/www/html
 RUN apk add --no-cache --update git
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 
-RUN apk add --no-cache ${PHPIZE_DEPS} \
-    && apk add --no-cache imagemagick imagemagick-dev \
-    && pecl install imagick \
-    && docker-php-ext-enable imagick
+RUN set -ex \
+    # Build dependencies
+    && apk add --no-cache --virtual .build-deps  \
+        $PHPIZE_DEPS \
+    && apk add --no-cache \
+    	libgomp \
+        freetype-dev \
+        libjpeg-turbo-dev \
+        libwebp-dev \
+        libpng-dev \
+    	libavif-dev \
+        imagemagick \
+        imagemagick-dev \
+    && pecl install imagick-3.7.0 \
+    && docker-php-ext-enable \
+        imagick \
+    && apk del .build-deps
 
 CMD tail -f /dev/null
 
-FROM php:8.2.0RC6-cli-alpine3.16 AS php82
+FROM php:8.2.21-cli-alpine3.20 AS php82
 
 CMD ["/bin/sh"]
 WORKDIR /var/www/html
@@ -21,9 +34,50 @@ WORKDIR /var/www/html
 RUN apk add --no-cache --update git
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 
-RUN apk add --no-cache ${PHPIZE_DEPS} \
-    && apk add --no-cache imagemagick imagemagick-dev \
-    && pecl install imagick \
-    && docker-php-ext-enable imagick
+RUN set -ex \
+    # Build dependencies
+    && apk add --no-cache --virtual .build-deps  \
+        $PHPIZE_DEPS \
+    && apk add --no-cache \
+    	libgomp \
+        freetype-dev \
+        libjpeg-turbo-dev \
+        libwebp-dev \
+        libpng-dev \
+    	libavif-dev \
+        imagemagick \
+        imagemagick-dev \
+    && pecl install imagick-3.7.0 \
+    && docker-php-ext-enable \
+        imagick \
+    && apk del .build-deps
+
+CMD tail -f /dev/null
+
+FROM php:8.3.9-cli-alpine3.20 AS php83
+
+CMD ["/bin/sh"]
+WORKDIR /var/www/html
+
+RUN apk add --no-cache --update git
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+
+RUN set -ex \
+    # Build dependencies
+    && apk add --no-cache --virtual .build-deps  \
+        $PHPIZE_DEPS \
+    && apk add --no-cache \
+    	libgomp \
+        freetype-dev \
+        libjpeg-turbo-dev \
+        libwebp-dev \
+        libpng-dev \
+    	libavif-dev \
+        imagemagick \
+        imagemagick-dev \
+    && pecl install imagick-3.7.0 \
+    && docker-php-ext-enable \
+        imagick \
+    && apk del .build-deps
 
 CMD tail -f /dev/null

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,7 @@ restart:
 tests.all:
 	PHP=81 make tests.run
 	PHP=82 make tests.run
+	PHP=83 make tests.run
 
 cs.fix:
 	PHP=81 make composer.update

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,3 +18,12 @@ services:
         container_name: 68publishers.image-storage.82
         volumes:
             - .:/var/www/html:cached
+
+    php83:
+        build:
+            context: .
+            dockerfile: Dockerfile
+            target: php83
+        container_name: 68publishers.image-storage.83
+        volumes:
+            - .:/var/www/html:cached

--- a/src/Bridge/Nette/DI/ImageStorageExtension.php
+++ b/src/Bridge/Nette/DI/ImageStorageExtension.php
@@ -373,7 +373,6 @@ final class ImageStorageExtension extends CompilerExtension implements FileStora
             ->setFactory(ImagePersister::class, [
                 new Reference($this->prefix('filesystem.' . $name)),
                 new Reference($this->prefix('config.' . $name)),
-                new Reference($this->prefix('modifier_facade.' . $name)),
             ])
             ->setAutowired(false);
 

--- a/src/FileInfo.php
+++ b/src/FileInfo.php
@@ -10,6 +10,7 @@ use SixtyEightPublishers\ImageStorage\Exception\InvalidStateException;
 use SixtyEightPublishers\ImageStorage\LinkGenerator\LinkGeneratorInterface as ImageLinkGeneratorInterface;
 use SixtyEightPublishers\ImageStorage\PathInfoInterface as ImagePathInfoInterface;
 use SixtyEightPublishers\ImageStorage\Responsive\Descriptor\DescriptorInterface;
+use SixtyEightPublishers\ImageStorage\Responsive\SrcSet;
 use function assert;
 
 final class FileInfo extends BaseFileInfo implements FileInfoInterface
@@ -19,7 +20,7 @@ final class FileInfo extends BaseFileInfo implements FileInfoInterface
         parent::__construct($linkGenerator, $pathInfo, $imageStorageName);
     }
 
-    public function srcSet(DescriptorInterface $descriptor): string
+    public function srcSet(DescriptorInterface $descriptor): SrcSet
     {
         assert($this->linkGenerator instanceof ImageLinkGeneratorInterface);
 

--- a/src/FileInfoInterface.php
+++ b/src/FileInfoInterface.php
@@ -6,8 +6,9 @@ namespace SixtyEightPublishers\ImageStorage;
 
 use SixtyEightPublishers\FileStorage\FileInfoInterface as BaseFileInfoInterface;
 use SixtyEightPublishers\ImageStorage\Responsive\Descriptor\DescriptorInterface;
+use SixtyEightPublishers\ImageStorage\Responsive\SrcSet;
 
 interface FileInfoInterface extends BaseFileInfoInterface, PathInfoInterface
 {
-    public function srcSet(DescriptorInterface $descriptor): string;
+    public function srcSet(DescriptorInterface $descriptor): SrcSet;
 }

--- a/src/ImageStorage.php
+++ b/src/ImageStorage.php
@@ -19,6 +19,7 @@ use SixtyEightPublishers\ImageStorage\NoImage\NoImageResolverInterface;
 use SixtyEightPublishers\ImageStorage\PathInfoInterface as ImagePathInfoInterface;
 use SixtyEightPublishers\ImageStorage\Persistence\ImagePersisterInterface;
 use SixtyEightPublishers\ImageStorage\Responsive\Descriptor\DescriptorInterface;
+use SixtyEightPublishers\ImageStorage\Responsive\SrcSet;
 use SixtyEightPublishers\ImageStorage\Security\SignatureStrategyInterface;
 use function assert;
 
@@ -89,7 +90,7 @@ final class ImageStorage extends FileStorage implements ImageStorageInterface
         return $this->noImageResolver->resolveNoImage($path);
     }
 
-    public function srcSet(ImagePathInfoInterface $info, DescriptorInterface $descriptor): string
+    public function srcSet(ImagePathInfoInterface $info, DescriptorInterface $descriptor): SrcSet
     {
         assert($this->linkGenerator instanceof ImageLinkGeneratorInterface);
 

--- a/src/LinkGenerator/LinkGenerator.php
+++ b/src/LinkGenerator/LinkGenerator.php
@@ -12,6 +12,7 @@ use SixtyEightPublishers\ImageStorage\Exception\InvalidArgumentException;
 use SixtyEightPublishers\ImageStorage\Modifier\Facade\ModifierFacadeInterface;
 use SixtyEightPublishers\ImageStorage\PathInfoInterface as ImagePathInfoInterface;
 use SixtyEightPublishers\ImageStorage\Responsive\Descriptor\DescriptorInterface;
+use SixtyEightPublishers\ImageStorage\Responsive\SrcSet;
 use SixtyEightPublishers\ImageStorage\Responsive\SrcSetGenerator;
 use SixtyEightPublishers\ImageStorage\Responsive\SrcSetGeneratorFactoryInterface;
 use SixtyEightPublishers\ImageStorage\Security\SignatureStrategyInterface;
@@ -49,7 +50,7 @@ final class LinkGenerator extends FileLinkGenerator implements LinkGeneratorInte
         return parent::link($pathInfo);
     }
 
-    public function srcSet(ImagePathInfoInterface $info, DescriptorInterface $descriptor): string
+    public function srcSet(ImagePathInfoInterface $info, DescriptorInterface $descriptor): SrcSet
     {
         if (null === $this->srcSetGenerator) {
             $this->srcSetGenerator = $this->srcSetGeneratorFactory->create($this, $this->modifierFacade);

--- a/src/LinkGenerator/LinkGeneratorInterface.php
+++ b/src/LinkGenerator/LinkGeneratorInterface.php
@@ -7,11 +7,12 @@ namespace SixtyEightPublishers\ImageStorage\LinkGenerator;
 use SixtyEightPublishers\FileStorage\LinkGenerator\LinkGeneratorInterface as BaseLinkGeneratorInterface;
 use SixtyEightPublishers\ImageStorage\PathInfoInterface;
 use SixtyEightPublishers\ImageStorage\Responsive\Descriptor\DescriptorInterface;
+use SixtyEightPublishers\ImageStorage\Responsive\SrcSet;
 use SixtyEightPublishers\ImageStorage\Security\SignatureStrategyInterface;
 
 interface LinkGeneratorInterface extends BaseLinkGeneratorInterface
 {
-    public function srcSet(PathInfoInterface $info, DescriptorInterface $descriptor): string;
+    public function srcSet(PathInfoInterface $info, DescriptorInterface $descriptor): SrcSet;
 
     public function getSignatureStrategy(): ?SignatureStrategyInterface;
 }

--- a/src/Modifier/Applicator/ModifierApplicatorInterface.php
+++ b/src/Modifier/Applicator/ModifierApplicatorInterface.php
@@ -11,5 +11,8 @@ use SixtyEightPublishers\ImageStorage\Modifier\Collection\ModifierValues;
 
 interface ModifierApplicatorInterface
 {
-    public function apply(Image $image, PathInfoInterface $pathInfo, ModifierValues $values, ConfigInterface $config): Image;
+    /**
+     * Returns NULL of image is not modified
+     */
+    public function apply(Image $image, PathInfoInterface $pathInfo, ModifierValues $values, ConfigInterface $config): ?Image;
 }

--- a/src/Modifier/Applicator/Orientation.php
+++ b/src/Modifier/Applicator/Orientation.php
@@ -14,14 +14,24 @@ use function is_string;
 
 final class Orientation implements ModifierApplicatorInterface
 {
-    public function apply(Image $image, PathInfoInterface $pathInfo, ModifierValues $values, ConfigInterface $config): Image
+    public function apply(Image $image, PathInfoInterface $pathInfo, ModifierValues $values, ConfigInterface $config): ?Image
     {
         $orientation = $values->getOptional(OrientationModifier::class);
 
         if (!is_string($orientation) && !is_numeric($orientation)) {
-            return $image;
+            return null;
         }
 
-        return ($orientation === 'auto') ? $image->orientate() : $image->rotate((float) $orientation);
+        if ('auto' === $orientation) {
+            $exifOrientation = $image->exif('Orientation');
+
+            if (2 <= $exifOrientation && 8 >= $exifOrientation) {
+                return $image->orientate();
+            }
+
+            return null;
+        }
+
+        return $image->rotate((float) $orientation);
     }
 }

--- a/src/Modifier/Applicator/Resize.php
+++ b/src/Modifier/Applicator/Resize.php
@@ -27,7 +27,7 @@ use function substr;
 
 final class Resize implements ModifierApplicatorInterface
 {
-    public function apply(Image $image, PathInfoInterface $pathInfo, ModifierValues $values, ConfigInterface $config): Image
+    public function apply(Image $image, PathInfoInterface $pathInfo, ModifierValues $values, ConfigInterface $config): ?Image
     {
         $width = $values->getOptional(Width::class);
         $height = $values->getOptional(Height::class);
@@ -70,7 +70,7 @@ final class Resize implements ModifierApplicatorInterface
         $height = (int) ($height * $pd);
 
         if ($width === $imageWidth && $height === $imageHeight) {
-            return $image;
+            return null;
         }
 
         switch ($fit) {

--- a/src/Modifier/Facade/ModifierFacade.php
+++ b/src/Modifier/Facade/ModifierFacade.php
@@ -102,7 +102,7 @@ final class ModifierFacade implements ModifierFacadeInterface
         return $this->codec;
     }
 
-    public function modifyImage(Image $image, PathInfoInterface $info, string|array $modifiers): Image
+    public function modifyImage(Image $image, PathInfoInterface $info, string|array $modifiers): ModifyResult
     {
         if (!is_array($modifiers)) {
             $modifiers = $this->getCodec()->decode(new PresetValue($modifiers));
@@ -118,10 +118,20 @@ final class ModifierFacade implements ModifierFacadeInterface
             $validator->validate($values, $this->config);
         }
 
+        $modified = false;
+
         foreach ($this->applicators as $applicator) {
-            $image = $applicator->apply($image, $info, $values, $this->config);
+            $modifiedImage = $applicator->apply($image, $info, $values, $this->config);
+
+            if (null !== $modifiedImage) {
+                $image = $modifiedImage;
+                $modified = true;
+            }
         }
 
-        return $image;
+        return new ModifyResult(
+            image: $image,
+            modified: $modified,
+        );
     }
 }

--- a/src/Modifier/Facade/ModifierFacadeInterface.php
+++ b/src/Modifier/Facade/ModifierFacadeInterface.php
@@ -41,5 +41,5 @@ interface ModifierFacadeInterface
     /**
      * @param string|array<string, string|numeric|bool> $modifiers
      */
-    public function modifyImage(Image $image, PathInfoInterface $info, string|array $modifiers): Image;
+    public function modifyImage(Image $image, PathInfoInterface $info, string|array $modifiers): ModifyResult;
 }

--- a/src/Modifier/Facade/ModifyResult.php
+++ b/src/Modifier/Facade/ModifyResult.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SixtyEightPublishers\ImageStorage\Modifier\Facade;
+
+use Intervention\Image\Image;
+
+final class ModifyResult
+{
+    public function __construct(
+        public readonly Image $image,
+        public readonly bool $modified,
+    ) {}
+}

--- a/src/Resource/ImageResource.php
+++ b/src/Resource/ImageResource.php
@@ -10,9 +10,12 @@ use SixtyEightPublishers\ImageStorage\Modifier\Facade\ModifierFacadeInterface;
 
 class ImageResource implements ResourceInterface
 {
+    private bool $modified = false;
+
     public function __construct(
         private PathInfoInterface $pathInfo,
         private Image $image,
+        private readonly string $localFilename,
         private readonly ModifierFacadeInterface $modifierFacade,
     ) {}
 
@@ -26,6 +29,16 @@ class ImageResource implements ResourceInterface
         return $this->image;
     }
 
+    public function getLocalFilename(): string
+    {
+        return $this->localFilename;
+    }
+
+    public function hasBeenModified(): bool
+    {
+        return $this->modified;
+    }
+
     public function withPathInfo(PathInfoInterface $pathInfo): self
     {
         $resource = clone $this;
@@ -37,7 +50,9 @@ class ImageResource implements ResourceInterface
     public function modifyImage(string|array $modifiers): self
     {
         $resource = clone $this;
-        $resource->image = $this->modifierFacade->modifyImage($this->image, $this->pathInfo, $modifiers);
+        $modifyResult = $this->modifierFacade->modifyImage($this->image, $this->pathInfo, $modifiers);
+        $resource->image = $modifyResult->image;
+        $resource->modified = $modifyResult->modified;
 
         return $resource;
     }

--- a/src/Resource/ResourceFactory.php
+++ b/src/Resource/ResourceFactory.php
@@ -81,6 +81,7 @@ final class ResourceFactory implements ResourceFactoryInterface
                     source: $filename,
                     location: $filename,
                 ),
+                localFilename: $filename,
                 modifierFacade: $this->modifierFacade,
             );
         }

--- a/src/Resource/ResourceInterface.php
+++ b/src/Resource/ResourceInterface.php
@@ -11,6 +11,10 @@ interface ResourceInterface extends FileResourceInterface
 {
     public function getSource(): Image;
 
+    public function getLocalFilename(): string;
+
+    public function hasBeenModified(): bool;
+
     /**
      * @param string|array<string, string|numeric|bool> $modifiers
      */

--- a/src/Resource/TmpFile.php
+++ b/src/Resource/TmpFile.php
@@ -11,7 +11,7 @@ final class TmpFile
     private bool $unlinked = false;
 
     public function __construct(
-        private readonly string $filename,
+        public readonly string $filename,
     ) {}
 
     /**

--- a/src/Resource/TmpFileImageResource.php
+++ b/src/Resource/TmpFileImageResource.php
@@ -19,6 +19,7 @@ final class TmpFileImageResource extends ImageResource
         parent::__construct(
             pathInfo: $pathInfo,
             image: $image,
+            localFilename: $this->tmpFile->filename,
             modifierFacade: $modifierFacade,
         );
     }

--- a/src/Responsive/Descriptor/DescriptorInterface.php
+++ b/src/Responsive/Descriptor/DescriptorInterface.php
@@ -4,9 +4,10 @@ declare(strict_types=1);
 
 namespace SixtyEightPublishers\ImageStorage\Responsive\Descriptor;
 
+use SixtyEightPublishers\ImageStorage\Responsive\SrcSet;
 use Stringable;
 
 interface DescriptorInterface extends Stringable
 {
-    public function createSrcSet(ArgsFacade $args): string;
+    public function createSrcSet(ArgsFacade $args): SrcSet;
 }

--- a/src/Responsive/SrcSet.php
+++ b/src/Responsive/SrcSet.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SixtyEightPublishers\ImageStorage\Responsive;
+
+use Stringable;
+
+final class SrcSet implements Stringable
+{
+    /**
+     * @param "x"|"w"                $descriptor
+     * @param array<numeric, string> $links
+     */
+    public function __construct(
+        public readonly string $descriptor,
+        public readonly array $links,
+        public readonly string $value,
+    ) {}
+
+    public function toString(): string
+    {
+        return $this->value;
+    }
+
+    public function __toString(): string
+    {
+        return $this->toString();
+    }
+}

--- a/src/Responsive/SrcSet.php
+++ b/src/Responsive/SrcSet.php
@@ -9,8 +9,8 @@ use Stringable;
 final class SrcSet implements Stringable
 {
     /**
-     * @param "x"|"w"                $descriptor
-     * @param array<numeric, string> $links
+     * @param "x"|"w"                   $descriptor
+     * @param array<int|string, string> $links
      */
     public function __construct(
         public readonly string $descriptor,

--- a/src/Responsive/SrcSetGenerator.php
+++ b/src/Responsive/SrcSetGenerator.php
@@ -13,7 +13,7 @@ use function array_key_exists;
 
 final class SrcSetGenerator
 {
-    /** @var array<string, string> */
+    /** @var array<string, SrcSet> */
     private array $results = [];
 
     public function __construct(
@@ -21,7 +21,7 @@ final class SrcSetGenerator
         private readonly ModifierFacadeInterface $modifierFacade,
     ) {}
 
-    public function generate(DescriptorInterface $descriptor, PathInfoInterface $pathInfo): string
+    public function generate(DescriptorInterface $descriptor, PathInfoInterface $pathInfo): SrcSet
     {
         $key = $descriptor . '::' . (empty($pathInfo->getModifiers()) ? $pathInfo->withModifiers(['original' => true]) : $pathInfo);
 

--- a/tests/FileInfoTest.phpt
+++ b/tests/FileInfoTest.phpt
@@ -12,6 +12,7 @@ use SixtyEightPublishers\ImageStorage\FileInfo;
 use SixtyEightPublishers\ImageStorage\LinkGenerator\LinkGeneratorInterface;
 use SixtyEightPublishers\ImageStorage\PathInfoInterface as ImagePathInfoInterface;
 use SixtyEightPublishers\ImageStorage\Responsive\Descriptor\DescriptorInterface;
+use SixtyEightPublishers\ImageStorage\Responsive\SrcSet;
 use Tester\Assert;
 use Tester\TestCase;
 use function call_user_func;
@@ -42,13 +43,21 @@ final class FileInfoTest extends TestCase
         $pathInfo = Mockery::mock(ImagePathInfoInterface::class);
         $descriptor = Mockery::mock(DescriptorInterface::class);
         $fileInfo = new FileInfo($linkGenerator, $pathInfo, 'default');
+        $srcSet = new SrcSet(
+            descriptor: 'w',
+            links: [
+                100 => 'var/www/h:100,w:100/file.png',
+                200 => 'var/www/h:100,w:200/file.png',
+            ],
+            value: 'var/www/h:100,w:100/file.png 100w, var/www/h:100,w:200/file.png 200w',
+        );
 
         $linkGenerator->shouldReceive('srcSet')
             ->once()
             ->with($fileInfo, $descriptor)
-            ->andReturn('srcset');
+            ->andReturn($srcSet);
 
-        Assert::same('srcset', $fileInfo->srcSet($descriptor));
+        Assert::same($srcSet, $fileInfo->srcSet($descriptor));
     }
 
     public function testModifiersShouldBeNullIfFilePathInfoPassed(): void

--- a/tests/ImageStorageTest.phpt
+++ b/tests/ImageStorageTest.phpt
@@ -20,6 +20,7 @@ use SixtyEightPublishers\ImageStorage\NoImage\NoImageResolverInterface;
 use SixtyEightPublishers\ImageStorage\PathInfoInterface as ImagePathInfoInterface;
 use SixtyEightPublishers\ImageStorage\Persistence\ImagePersisterInterface;
 use SixtyEightPublishers\ImageStorage\Responsive\Descriptor\DescriptorInterface;
+use SixtyEightPublishers\ImageStorage\Responsive\SrcSet;
 use SixtyEightPublishers\ImageStorage\Security\SignatureStrategyInterface;
 use Tester\Assert;
 use Tester\TestCase;
@@ -237,15 +238,23 @@ final class ImageStorageTest extends TestCase
         $linkGenerator = Mockery::mock(LinkGeneratorInterface::class);
         $pathInfo = Mockery::mock(ImagePathInfoInterface::class);
         $descriptor = Mockery::mock(DescriptorInterface::class);
+        $srcSet = new SrcSet(
+            descriptor: 'w',
+            links: [
+                100 => 'var/www/h:100,w:100/file.png',
+                200 => 'var/www/h:100,w:200/file.png',
+            ],
+            value: 'var/www/h:100,w:100/file.png 100w, var/www/h:100,w:200/file.png 200w',
+        );
 
         $linkGenerator->shouldReceive('srcSet')
             ->once()
             ->with($pathInfo, $descriptor)
-            ->andReturn('srcset');
+            ->andReturn($srcSet);
 
         $imageStorage = $this->createImageStorage(linkGenerator: $linkGenerator);
 
-        Assert::same('srcset', $imageStorage->srcSet($pathInfo, $descriptor));
+        Assert::same($srcSet, $imageStorage->srcSet($pathInfo, $descriptor));
     }
 
     public function testSignatureStrategyShouldBeReturned(): void

--- a/tests/LinkGenerator/LinkGeneratorTest.phpt
+++ b/tests/LinkGenerator/LinkGeneratorTest.phpt
@@ -13,6 +13,7 @@ use SixtyEightPublishers\ImageStorage\LinkGenerator\LinkGenerator;
 use SixtyEightPublishers\ImageStorage\Modifier\Facade\ModifierFacadeInterface;
 use SixtyEightPublishers\ImageStorage\PathInfoInterface as ImagePathInfoInterface;
 use SixtyEightPublishers\ImageStorage\Responsive\Descriptor\DescriptorInterface;
+use SixtyEightPublishers\ImageStorage\Responsive\SrcSet;
 use SixtyEightPublishers\ImageStorage\Responsive\SrcSetGenerator;
 use SixtyEightPublishers\ImageStorage\Responsive\SrcSetGeneratorFactoryInterface;
 use SixtyEightPublishers\ImageStorage\Security\SignatureStrategyInterface;
@@ -133,6 +134,13 @@ final class LinkGeneratorTest extends TestCase
         $pathInfo = Mockery::mock(ImagePathInfoInterface::class);
         $descriptor = Mockery::mock(DescriptorInterface::class);
         $linkGenerator = new LinkGenerator(new Config([]), $modifierFacade, $srcSetGeneratorFactory);
+        $srcSet = new SrcSet(
+            descriptor: 'test',
+            links: [
+                1 => 'srcset',
+            ],
+            value: 'srcset',
+        );
 
         $srcSetGeneratorFactory->shouldReceive('create')
             ->once()
@@ -142,10 +150,10 @@ final class LinkGeneratorTest extends TestCase
         $srcSetGenerator->shouldReceive('generate')
             ->times(2)
             ->with($descriptor, $pathInfo)
-            ->andReturn('srcset');
+            ->andReturn($srcSet);
 
-        Assert::same('srcset', $linkGenerator->srcSet($pathInfo, $descriptor));
-        Assert::same('srcset', $linkGenerator->srcSet($pathInfo, $descriptor));
+        Assert::same($srcSet, $linkGenerator->srcSet($pathInfo, $descriptor));
+        Assert::same($srcSet, $linkGenerator->srcSet($pathInfo, $descriptor));
     }
 
     public function tearDown(): void

--- a/tests/Modifier/Applicator/ResizeTest.phpt
+++ b/tests/Modifier/Applicator/ResizeTest.phpt
@@ -61,7 +61,7 @@ final class ResizeTest extends TestCase
     /**
      * @dataProvider getSameImageDimensionsData
      */
-    public function testImageShouldNotBeModifiedIfCalculatedDimensionsAreSameAsOriginal(int $imageWidth, int $imageHeight, ?int $widthValue, ?int $heightValue, float $pd, array $aspectRatio): void
+    public function testNullShouldBeReturnedIfCalculatedDimensionsAreSameAsOriginal(int $imageWidth, int $imageHeight, ?int $widthValue, ?int $heightValue, float $pd, array $aspectRatio): void
     {
         $image = Mockery::mock(Image::class);
         $pathInfo = Mockery::mock(PathInfoInterface::class);
@@ -80,7 +80,7 @@ final class ResizeTest extends TestCase
 
         $applicator = new Resize();
 
-        Assert::same($image, $applicator->apply($image, $pathInfo, $modifierValues, $config));
+        Assert::null($applicator->apply($image, $pathInfo, $modifierValues, $config));
     }
 
     public function testImageShouldBeModifiedWithContainFit(): void

--- a/tests/Resource/ImageResourceTest.phpt
+++ b/tests/Resource/ImageResourceTest.phpt
@@ -8,6 +8,7 @@ use Intervention\Image\Image;
 use Mockery;
 use SixtyEightPublishers\FileStorage\PathInfoInterface as FilePathInfoInterface;
 use SixtyEightPublishers\ImageStorage\Modifier\Facade\ModifierFacadeInterface;
+use SixtyEightPublishers\ImageStorage\Modifier\Facade\ModifyResult;
 use SixtyEightPublishers\ImageStorage\Resource\ImageResource;
 use Tester\Assert;
 use Tester\TestCase;
@@ -23,12 +24,15 @@ final class ImageResourceTest extends TestCase
         $pathInfo1 = Mockery::mock(FilePathInfoInterface::class);
         $pathInfo2 = Mockery::mock(FilePathInfoInterface::class);
 
-        $resource1 = new ImageResource($pathInfo1, $image, $modifierFacade);
+        $resource1 = new ImageResource($pathInfo1, $image, '/tmp/image.png', $modifierFacade);
         $resource2 = $resource1->withPathInfo($pathInfo2);
 
         Assert::notSame($resource1, $resource2);
         Assert::same($pathInfo1, $resource1->getPathInfo());
         Assert::same($pathInfo2, $resource2->getPathInfo());
+
+        Assert::same('/tmp/image.png', $resource1->getLocalFilename());
+        Assert::same('/tmp/image.png', $resource2->getLocalFilename());
     }
 
     public function testImageShouldBeModified(): void
@@ -37,18 +41,24 @@ final class ImageResourceTest extends TestCase
         $modifierFacade = Mockery::mock(ModifierFacadeInterface::class);
         $image = Mockery::mock(Image::class);
         $modifiedImage = Mockery::mock(Image::class);
+        $modifyResult = new ModifyResult(
+            image: $modifiedImage,
+            modified: true,
+        );
 
         $modifierFacade->shouldReceive('modifyImage')
             ->once()
             ->with($image, $pathInfo, ['w' => 300])
-            ->andReturn($modifiedImage);
+            ->andReturn($modifyResult);
 
-        $resource1 = new ImageResource($pathInfo, $image, $modifierFacade);
+        $resource1 = new ImageResource($pathInfo, $image, '/tmp/image.png', $modifierFacade);
         $resource2 = $resource1->modifyImage(['w' => 300]);
 
         Assert::notSame($resource1, $resource2);
         Assert::same($image, $resource1->getSource());
         Assert::same($modifiedImage, $resource2->getSource());
+        Assert::false($resource1->hasBeenModified());
+        Assert::true($resource2->hasBeenModified());
     }
 
     protected function tearDown(): void

--- a/tests/Responsive/Descriptor/WDescriptorTest.phpt
+++ b/tests/Responsive/Descriptor/WDescriptorTest.phpt
@@ -10,6 +10,7 @@ use SixtyEightPublishers\ImageStorage\Exception\InvalidArgumentException;
 use SixtyEightPublishers\ImageStorage\Modifier\Width;
 use SixtyEightPublishers\ImageStorage\Responsive\Descriptor\ArgsFacade;
 use SixtyEightPublishers\ImageStorage\Responsive\Descriptor\WDescriptor;
+use SixtyEightPublishers\ImageStorage\Responsive\SrcSet;
 use Tester\Assert;
 use Tester\TestCase;
 use function call_user_func;
@@ -69,7 +70,7 @@ final class WDescriptorTest extends TestCase
         Assert::same('W(100,200,300)', (string) new WDescriptor(100, 200, 300));
     }
 
-    public function testSrcSetShouldBeEmptyStringIfWidthModifierNotFoundAndDefaultModifiersAreNull(): void
+    public function testSrcSetShouldBeEmptyIfWidthModifierNotFoundAndDefaultModifiersAreNull(): void
     {
         $argsFacade = Mockery::mock(ArgsFacade::class);
 
@@ -85,10 +86,17 @@ final class WDescriptorTest extends TestCase
 
         $descriptor = new WDescriptor(100, 200, 300);
 
-        Assert::same('', $descriptor->createSrcSet($argsFacade));
+        Assert::equal(
+            new SrcSet(
+                descriptor: 'w',
+                links: [],
+                value: '',
+            ),
+            $descriptor->createSrcSet($argsFacade),
+        );
     }
 
-    public function testSrcSetShouldBeEmptyStringIfWidthModifierNotFoundAndDefaultModifiersAreEmptyArray(): void
+    public function testSrcSetShouldBeEmptyIfWidthModifierNotFoundAndDefaultModifiersAreEmptyArray(): void
     {
         $argsFacade = Mockery::mock(ArgsFacade::class);
 
@@ -104,7 +112,14 @@ final class WDescriptorTest extends TestCase
 
         $descriptor = new WDescriptor(100, 200, 300);
 
-        Assert::same('', $descriptor->createSrcSet($argsFacade));
+        Assert::equal(
+            new SrcSet(
+                descriptor: 'w',
+                links: [],
+                value: '',
+            ),
+            $descriptor->createSrcSet($argsFacade),
+        );
     }
 
     public function testSrcSetShouldBeSingleLinkIfWidthModifierNotFound(): void
@@ -128,10 +143,19 @@ final class WDescriptorTest extends TestCase
 
         $descriptor = new WDescriptor(100, 200, 300);
 
-        Assert::same('var/www/h:100/file.png', $descriptor->createSrcSet($argsFacade));
+        Assert::equal(
+            new SrcSet(
+                descriptor: 'w',
+                links: [
+                    0 => 'var/www/h:100/file.png',
+                ],
+                value: 'var/www/h:100/file.png',
+            ),
+            $descriptor->createSrcSet($argsFacade),
+        );
     }
 
-    public function testSrcSetShouldBeEmptyStringIfNoWidthsDefined(): void
+    public function testSrcSetShouldBeEmptyIfNoWidthsDefined(): void
     {
         $argsFacade = Mockery::mock(ArgsFacade::class);
 
@@ -147,7 +171,14 @@ final class WDescriptorTest extends TestCase
 
         $descriptor = new WDescriptor();
 
-        Assert::same('', $descriptor->createSrcSet($argsFacade));
+        Assert::equal(
+            new SrcSet(
+                descriptor: 'w',
+                links: [],
+                value: '',
+            ),
+            $descriptor->createSrcSet($argsFacade),
+        );
     }
 
     public function testSrcSetShouldContainMultipleLinksWithoutDefaultModifiers(): void
@@ -181,7 +212,18 @@ final class WDescriptorTest extends TestCase
 
         $descriptor = new WDescriptor(100, 200, 300);
 
-        Assert::same('var/www/w:100/file.png 100w, var/www/w:200/file.png 200w, var/www/w:300/file.png 300w', $descriptor->createSrcSet($argsFacade));
+        Assert::equal(
+            new SrcSet(
+                descriptor: 'w',
+                links: [
+                    100 => 'var/www/w:100/file.png',
+                    200 => 'var/www/w:200/file.png',
+                    300 => 'var/www/w:300/file.png',
+                ],
+                value: 'var/www/w:100/file.png 100w, var/www/w:200/file.png 200w, var/www/w:300/file.png 300w',
+            ),
+            $descriptor->createSrcSet($argsFacade),
+        );
     }
 
     public function testSrcSetShouldContainMultipleLinksWithDefaultModifiers(): void
@@ -215,7 +257,18 @@ final class WDescriptorTest extends TestCase
 
         $descriptor = new WDescriptor(100, 200, 300);
 
-        Assert::same('var/www/h:100,w:100/file.png 100w, var/www/h:100,w:200/file.png 200w, var/www/h:100,w:300/file.png 300w', $descriptor->createSrcSet($argsFacade));
+        Assert::equal(
+            new SrcSet(
+                descriptor: 'w',
+                links: [
+                    100 => 'var/www/h:100,w:100/file.png',
+                    200 => 'var/www/h:100,w:200/file.png',
+                    300 => 'var/www/h:100,w:300/file.png',
+                ],
+                value: 'var/www/h:100,w:100/file.png 100w, var/www/h:100,w:200/file.png 200w, var/www/h:100,w:300/file.png 300w',
+            ),
+            $descriptor->createSrcSet($argsFacade),
+        );
     }
 
     public function getInvalidRangeData(): array

--- a/tests/Responsive/Descriptor/XDescriptorTest.phpt
+++ b/tests/Responsive/Descriptor/XDescriptorTest.phpt
@@ -9,6 +9,7 @@ use Mockery;
 use SixtyEightPublishers\ImageStorage\Modifier\PixelDensity;
 use SixtyEightPublishers\ImageStorage\Responsive\Descriptor\ArgsFacade;
 use SixtyEightPublishers\ImageStorage\Responsive\Descriptor\XDescriptor;
+use SixtyEightPublishers\ImageStorage\Responsive\SrcSet;
 use Tester\Assert;
 use Tester\TestCase;
 use function call_user_func;
@@ -37,7 +38,7 @@ final class XDescriptorTest extends TestCase
         Assert::same('X(1,2,3)', (string) new XDescriptor(1.0, 2.0, 3.0));
     }
 
-    public function testSrcSetShouldBeEmptyStringIfPixelDensityModifierNotFoundAndDefaultModifiersAreNull(): void
+    public function testSrcSetShouldBeEmptyIfPixelDensityModifierNotFoundAndDefaultModifiersAreNull(): void
     {
         $argsFacade = Mockery::mock(ArgsFacade::class);
 
@@ -53,10 +54,13 @@ final class XDescriptorTest extends TestCase
 
         $descriptor = new XDescriptor(1, 2, 2.5);
 
-        Assert::same('', $descriptor->createSrcSet($argsFacade));
+        Assert::equal(
+            new SrcSet(descriptor: 'x', links: [], value: ''),
+            $descriptor->createSrcSet($argsFacade),
+        );
     }
 
-    public function testSrcSetShouldBeEmptyStringIfPixelDensityModifierNotFoundAndDefaultModifiersAreEmptyArray(): void
+    public function testSrcSetShouldBeEmptyIfPixelDensityModifierNotFoundAndDefaultModifiersAreEmptyArray(): void
     {
         $argsFacade = Mockery::mock(ArgsFacade::class);
 
@@ -72,7 +76,10 @@ final class XDescriptorTest extends TestCase
 
         $descriptor = new XDescriptor(1, 2, 2.5);
 
-        Assert::same('', $descriptor->createSrcSet($argsFacade));
+        Assert::equal(
+            new SrcSet(descriptor: 'x', links: [], value: ''),
+            $descriptor->createSrcSet($argsFacade),
+        );
     }
 
     public function testSrcSetShouldBeSingleLinkIfWidthModifierNotFound(): void
@@ -96,7 +103,14 @@ final class XDescriptorTest extends TestCase
 
         $descriptor = new XDescriptor(1, 2, 2.5);
 
-        Assert::same('var/www/h:100/file.png', $descriptor->createSrcSet($argsFacade));
+        Assert::equal(
+            new SrcSet(
+                descriptor: 'x',
+                links: ['1.0' => 'var/www/h:100/file.png'],
+                value: 'var/www/h:100/file.png',
+            ),
+            $descriptor->createSrcSet($argsFacade),
+        );
     }
 
     public function testSrcSetShouldContainMultipleLinksWithoutDefaultModifiers(): void
@@ -130,7 +144,18 @@ final class XDescriptorTest extends TestCase
 
         $descriptor = new XDescriptor(1, 2, 2.5);
 
-        Assert::same('var/www/pd:1/file.png, var/www/pd:2/file.png 2.0x, var/www/pd:2.5/file.png 2.5x', $descriptor->createSrcSet($argsFacade));
+        Assert::equal(
+            new SrcSet(
+                descriptor: 'x',
+                links: [
+                    '1.0' => 'var/www/pd:1/file.png',
+                    '2.0' => 'var/www/pd:2/file.png',
+                    '2.5' => 'var/www/pd:2.5/file.png',
+                ],
+                value: 'var/www/pd:1/file.png, var/www/pd:2/file.png 2.0x, var/www/pd:2.5/file.png 2.5x',
+            ),
+            $descriptor->createSrcSet($argsFacade),
+        );
     }
 
     public function testSrcSetShouldContainMultipleLinksWithDefaultModifiers(): void
@@ -164,7 +189,18 @@ final class XDescriptorTest extends TestCase
 
         $descriptor = new XDescriptor(1, 2, 2.5);
 
-        Assert::same('var/www/h:100,pd:1/file.png, var/www/h:100,pd:2/file.png 2.0x, var/www/h:100,pd:2.5/file.png 2.5x', $descriptor->createSrcSet($argsFacade));
+        Assert::equal(
+            new SrcSet(
+                descriptor: 'x',
+                links: [
+                    '1.0' => 'var/www/h:100,pd:1/file.png',
+                    '2.0' => 'var/www/h:100,pd:2/file.png',
+                    '2.5' => 'var/www/h:100,pd:2.5/file.png',
+                ],
+                value: 'var/www/h:100,pd:1/file.png, var/www/h:100,pd:2/file.png 2.0x, var/www/h:100,pd:2.5/file.png 2.5x',
+            ),
+            $descriptor->createSrcSet($argsFacade),
+        );
     }
 
     protected function tearDown(): void

--- a/tests/Responsive/SrcSetGeneratorTest.phpt
+++ b/tests/Responsive/SrcSetGeneratorTest.phpt
@@ -11,6 +11,7 @@ use SixtyEightPublishers\ImageStorage\Modifier\Facade\ModifierFacadeInterface;
 use SixtyEightPublishers\ImageStorage\PathInfoInterface;
 use SixtyEightPublishers\ImageStorage\Responsive\Descriptor\ArgsFacade;
 use SixtyEightPublishers\ImageStorage\Responsive\Descriptor\DescriptorInterface;
+use SixtyEightPublishers\ImageStorage\Responsive\SrcSet;
 use SixtyEightPublishers\ImageStorage\Responsive\SrcSetGenerator;
 use Tester\Assert;
 use Tester\TestCase;
@@ -27,6 +28,13 @@ final class SrcSetGeneratorTest extends TestCase
         $descriptor = Mockery::mock(DescriptorInterface::class);
         $pathInfo = Mockery::mock(PathInfoInterface::class);
         $modifiedPathInfo = Mockery::mock(PathInfoInterface::class);
+        $srcSet = new SrcSet(
+            descriptor: 'test',
+            links: [
+                1 => 'srcset',
+            ],
+            value: 'srcset',
+        );
 
         $descriptor->shouldReceive('__toString')
             ->times(2)
@@ -51,26 +59,26 @@ final class SrcSetGeneratorTest extends TestCase
         $descriptor->shouldReceive('createSrcSet')
             ->times(1)
             ->with(Mockery::type(ArgsFacade::class))
-            ->andReturnUsing(function (ArgsFacade $facade) use ($linkGenerator, $modifierFacade, $pathInfo): string {
+            ->andReturnUsing(function (ArgsFacade $facade) use ($linkGenerator, $modifierFacade, $pathInfo, $srcSet): SrcSet {
                 $this->assertFacadeProperties($facade, $linkGenerator, $modifierFacade, $pathInfo);
 
-                return 'srcset';
+                return $srcSet;
             });
 
         $generator = new SrcSetGenerator($linkGenerator, $modifierFacade);
 
         $this->assertCache($generator, []);
 
-        Assert::same('srcset', $generator->generate($descriptor, $pathInfo));
+        Assert::same($srcSet, $generator->generate($descriptor, $pathInfo));
 
         $this->assertCache($generator, [
-            'TEST()::var/www/original/file.png' => 'srcset',
+            'TEST()::var/www/original/file.png' => $srcSet,
         ]);
 
-        Assert::same('srcset', $generator->generate($descriptor, $pathInfo));
+        Assert::same($srcSet, $generator->generate($descriptor, $pathInfo));
 
         $this->assertCache($generator, [
-            'TEST()::var/www/original/file.png' => 'srcset',
+            'TEST()::var/www/original/file.png' => $srcSet,
         ]);
     }
 
@@ -80,6 +88,13 @@ final class SrcSetGeneratorTest extends TestCase
         $modifierFacade = Mockery::mock(ModifierFacadeInterface::class);
         $descriptor = Mockery::mock(DescriptorInterface::class);
         $pathInfo = Mockery::mock(PathInfoInterface::class);
+        $srcSet = new SrcSet(
+            descriptor: 'test',
+            links: [
+                1 => 'srcset',
+            ],
+            value: 'srcset',
+        );
 
         $descriptor->shouldReceive('__toString')
             ->times(2)
@@ -99,26 +114,26 @@ final class SrcSetGeneratorTest extends TestCase
         $descriptor->shouldReceive('createSrcSet')
             ->times(1)
             ->with(Mockery::type(ArgsFacade::class))
-            ->andReturnUsing(function (ArgsFacade $facade) use ($linkGenerator, $modifierFacade, $pathInfo): string {
+            ->andReturnUsing(function (ArgsFacade $facade) use ($linkGenerator, $modifierFacade, $pathInfo, $srcSet): SrcSet {
                 $this->assertFacadeProperties($facade, $linkGenerator, $modifierFacade, $pathInfo);
 
-                return 'srcset';
+                return $srcSet;
             });
 
         $generator = new SrcSetGenerator($linkGenerator, $modifierFacade);
 
         $this->assertCache($generator, []);
 
-        Assert::same('srcset', $generator->generate($descriptor, $pathInfo));
+        Assert::same($srcSet, $generator->generate($descriptor, $pathInfo));
 
         $this->assertCache($generator, [
-            'TEST()::var/www/h:100/file.png' => 'srcset',
+            'TEST()::var/www/h:100/file.png' => $srcSet,
         ]);
 
-        Assert::same('srcset', $generator->generate($descriptor, $pathInfo));
+        Assert::same($srcSet, $generator->generate($descriptor, $pathInfo));
 
         $this->assertCache($generator, [
-            'TEST()::var/www/h:100/file.png' => 'srcset',
+            'TEST()::var/www/h:100/file.png' => $srcSet,
         ]);
     }
 

--- a/tests/Responsive/SrcSetTest.phpt
+++ b/tests/Responsive/SrcSetTest.phpt
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SixtyEightPublishers\ImageStorage\Tests\Responsive;
+
+use SixtyEightPublishers\ImageStorage\Responsive\SrcSet;
+use Tester\Assert;
+use Tester\TestCase;
+
+require __DIR__ . '/../bootstrap.php';
+
+final class SrcSetTest extends TestCase
+{
+    public function testSrcSetShouldBeConvertedToString(): void
+    {
+        $srcSet = new SrcSet(
+            descriptor: 'w',
+            links: [
+                100 => 'var/www/h:100,w:100/file.png',
+                200 => 'var/www/h:100,w:200/file.png',
+                300 => 'var/www/h:100,w:300/file.png',
+            ],
+            value: 'var/www/h:100,w:100/file.png 100w, var/www/h:100,w:200/file.png 200w, var/www/h:100,w:300/file.png 300w',
+        );
+
+        Assert::same('var/www/h:100,w:100/file.png 100w, var/www/h:100,w:200/file.png 200w, var/www/h:100,w:300/file.png 300w', $srcSet->toString());
+        Assert::same('var/www/h:100,w:100/file.png 100w, var/www/h:100,w:200/file.png 200w, var/www/h:100,w:300/file.png 300w', (string) $srcSet);
+    }
+}
+
+(new SrcSetTest())->run();


### PR DESCRIPTION
- improved image persistence - if the source image has not really been modified, the original is used, thus avoiding the increase in filesize
- methods `LinkGeneratorInterface::srcSet()` and `ImageStorageInterface::srcSet()` now returns object of type `SrcSet` instead of string
- fixed Imagick installations in Dockerfile
- added Docker image for PHP 8.3